### PR TITLE
feat(dev): minikube deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
 bin/
+config/minikube/.secrets

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ go.work.sum
 !vendor/**/zz_generated.*
 bundle/manifests/*
 kubeconfig
+config/minikube/.secrets
 
 # editor and IDE paraphernalia
 .idea

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,9 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
+minikube-setup: kustomize minikube-secrets
+	$(KUSTOMIZE) build config/minikube | $(KUBECTL) apply -f -
+
 minikube-secrets: config/minikube/.secrets/publishing-database.txt config/minikube/.secrets/subscribing-database.txt
 
 config/minikube/.secrets/publishing-database.txt config/minikube/.secrets/subscribing-database.txt:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,33 @@ make uninstall
 make undeploy
 ```
 
+## Development
+
+### Prerequisites
+
+* [Podman](https://podman.io/)
+* [Minikube](https://minikube.sigs.k8s.io/docs/start/)
+  ```
+  curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+  sudo install minikube-linux-amd64 /usr/local/bin/minikube
+  ```
+
+### Environment Setup
+
+To set up the development environment using Minikube, first create and start the Minikube cluster:
+```
+minikube start
+```
+
+Then run:
+```
+make minikube-setup
+```
+
+This would:
+* generate two secret files for two testing datbases under `config/minikube/.secrets`
+* deploy two postrgresql instances (one for publishing the other for subscribing)
+
 ## Project Distribution
 
 Following are the steps to build the installer and distribute this project to users.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ make minikube-setup
 This would:
 * generate two secret files for two testing datbases under `config/minikube/.secrets`
 * deploy two postrgresql instances (one for publishing the other for subscribing)
+* inject example data to the publishing database under `published_data` schema
 
 ## Project Distribution
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ make undeploy
 
 To set up the development environment using Minikube, first create and start the Minikube cluster:
 ```
-minikube start
+minikube start --addons=registry
 ```
 
 Then run:
@@ -93,6 +93,14 @@ This would:
 * generate two secret files for two testing datbases under `config/minikube/.secrets`
 * deploy two postrgresql instances (one for publishing the other for subscribing)
 * inject example data to the publishing database under `published_data` schema
+
+To build and deploy it to minikube use:
+```
+make deploy-minikube
+```
+
+Please note, that the image would be labeled in a format of `SHORT_GIT_HASH-YYYMMDDHHmm`.
+To control the label, set the `VERSION` variable.
 
 ## Project Distribution
 

--- a/config/minikube/kustomization.yaml
+++ b/config/minikube/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: default
 resources:
   - ./publishing-database
   - ./subscribing-database
+  - populator.yaml
 
 generatorOptions:
   # needed for secrets to be accessible by operator created cronjobs

--- a/config/minikube/kustomization.yaml
+++ b/config/minikube/kustomization.yaml
@@ -1,6 +1,10 @@
 # Adds namespace to all resources.
 namespace: default
 
+resources:
+  - ./publishing-database
+  - ./subscribing-database
+
 generatorOptions:
   # needed for secrets to be accessible by operator created cronjobs
   disableNameSuffixHash: true

--- a/config/minikube/kustomization.yaml
+++ b/config/minikube/kustomization.yaml
@@ -1,0 +1,16 @@
+# Adds namespace to all resources.
+namespace: default
+
+generatorOptions:
+  # needed for secrets to be accessible by operator created cronjobs
+  disableNameSuffixHash: true
+
+secretGenerator:
+- name: publishing-database
+  type: Opaque
+  envs:
+  - .secrets/publishing-database.txt
+- name: subscribing-database
+  type: Opaque
+  envs:
+  - .secrets/subscribing-database.txt

--- a/config/minikube/populator.yaml
+++ b/config/minikube/populator.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: populator
+    pod: test-app
+  name: populator
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app: populator
+        pod: test-app
+    spec:
+      containers:
+      - args:
+        - -c
+        - /tmp/app.sh
+        command:
+        - /bin/bash
+        env:
+        - name: PGHOST
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: publishing-database
+        - name: PGDATABASE
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: publishing-database
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: publishing-database
+        - name: PGPORT
+          valueFrom:
+            secretKeyRef:
+              key: db.port
+              name: publishing-database
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              key: db.user
+              name: publishing-database
+        image: docker.io/postgres:16
+        name: populator
+        resources:
+          limits:
+            cpu: 50m
+            memory: 100Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /tmp
+          name: app-script-volume
+      restartPolicy: OnFailure
+      volumes:
+      - configMap:
+          defaultMode: 493
+          name: populator-script
+        name: app-script-volume
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: populator-script
+data:
+  app.sh: |
+    set -e
+    psql <<EOF
+      CREATE SCHEMA IF NOT EXISTS published_data;
+      CREATE TABLE IF NOT EXISTS published_data.people
+        (id UUID PRIMARY KEY, name VARCHAR(255), email VARCHAR(255) UNIQUE, birthyear INT);
+      INSERT INTO published_data.people VALUES
+        (gen_random_uuid(), 'My Name', 'My Email', 9999),
+        (gen_random_uuid(), 'Your Name', 'Your Email', 1111)
+        ON CONFLICT DO NOTHING;
+      CREATE TABLE IF NOT EXISTS published_data.cities
+        (id UUID PRIMARY KEY, name VARCHAR(255) UNIQUE, zip VARCHAR(255), country VARCHAR(255));
+      INSERT INTO published_data.cities VALUES
+        (gen_random_uuid(), 'Ney York', '900 22', 'USA'),
+        (gen_random_uuid(), 'Rio', '111 88', 'Brazil'),
+        (gen_random_uuid(), 'Tokyo', '91378', 'Japan')
+        ON CONFLICT DO NOTHING;
+    EOF

--- a/config/minikube/postgresql-db-base/kustomization.yaml
+++ b/config/minikube/postgresql-db-base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - postgresql-db.yaml
+

--- a/config/minikube/postgresql-db-base/postgresql-db.yaml
+++ b/config/minikube/postgresql-db-base/postgresql-db.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: postgresql
+    service: db
+  name: postgresql-db
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: postgresql
+      service: db
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: postgresql
+        service: db
+    spec:
+      containers:
+      - env: []
+        image: quay.io/cloudservices/postgresql-rds:16-759c25d
+        livenessProbe:
+          exec:
+            command:
+            - psql
+            - -U
+            - $(POSTGRESQL_USER)
+            - -d
+            - $(POSTGRESQL_DATABASE)
+            - -c
+            - SELECT 1
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: db
+        ports:
+        - containerPort: 5432
+          name: database
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - psql
+            - -U
+            - $(POSTGRESQL_USER)
+            - -d
+            - $(POSTGRESQL_DATABASE)
+            - -c
+            - SELECT 1
+          failureThreshold: 3
+          initialDelaySeconds: 45
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /var/lib/pgsql/data
+          name: db-storage
+      restartPolicy: Always
+      volumes:
+      - emptyDir: {}
+        name: db-storage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: postgresql
+    service: db
+  name: database
+spec:
+  selector:
+    app: postgresql
+    service: db
+  ports:
+  - port: 5432
+    targetPort: 5432

--- a/config/minikube/publishing-database/kustomization.yaml
+++ b/config/minikube/publishing-database/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+  - ../postgresql-db-base
+
+patches:
+  - path: patch-deployment.yaml
+    target:
+      kind: Deployment
+      name: postgresql-db
+  - path: patch-service.yaml
+    target:
+      kind: Service
+      name: database

--- a/config/minikube/publishing-database/patch-deployment.yaml
+++ b/config/minikube/publishing-database/patch-deployment.yaml
@@ -1,0 +1,65 @@
+- op: replace
+  path: /metadata/name
+  value: publishing-database
+- op: add
+  path: /metadata/labels/designation
+  value: publishing
+- op: add
+  path: /spec/selector/matchLabels/designation
+  value: publishing
+- op: add
+  path: /spec/template/metadata/labels/designation
+  value: publishing
+- op: add
+  path: /metadata/labels/designation
+  value: publishing
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_USER
+    valueFrom:
+      secretKeyRef:
+        key: db.user
+        name: publishing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        key: db.password
+        name: publishing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: PGPASSWORD
+    valueFrom:
+      secretKeyRef:
+        key: db.admin_password
+        name: publishing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_MASTER_USER
+    valueFrom:
+      secretKeyRef:
+        key: db.admin_user
+        name: publishing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_MASTER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        key: db.admin_password
+        name: publishing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_DATABASE
+    valueFrom:
+      secretKeyRef:
+        key: db.name
+        name: publishing-database
+
+

--- a/config/minikube/publishing-database/patch-service.yaml
+++ b/config/minikube/publishing-database/patch-service.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: publishing-database
+- op: add
+  path: /metadata/labels/designation
+  value: publishing
+- op: add
+  path: /spec/selector/designation
+  value: publishing

--- a/config/minikube/subscribing-database/kustomization.yaml
+++ b/config/minikube/subscribing-database/kustomization.yaml
@@ -1,0 +1,13 @@
+
+resources:
+  - ../postgresql-db-base
+
+patches:
+  - path: patch-deployment.yaml
+    target:
+      kind: Deployment
+      name: postgresql-db
+  - path: patch-service.yaml
+    target:
+      kind: Service
+      name: database

--- a/config/minikube/subscribing-database/patch-deployment.yaml
+++ b/config/minikube/subscribing-database/patch-deployment.yaml
@@ -1,0 +1,65 @@
+- op: replace
+  path: /metadata/name
+  value: subscribing-database
+- op: add
+  path: /metadata/labels/designation
+  value: subscribing
+- op: add
+  path: /spec/selector/matchLabels/designation
+  value: subscribing
+- op: add
+  path: /spec/template/metadata/labels/designation
+  value: subscribing
+- op: add
+  path: /metadata/labels/designation
+  value: subscribing
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_USER
+    valueFrom:
+      secretKeyRef:
+        key: db.user
+        name: subscribing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        key: db.password
+        name: subscribing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: PGPASSWORD
+    valueFrom:
+      secretKeyRef:
+        key: db.admin_password
+        name: subscribing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_MASTER_USER
+    valueFrom:
+      secretKeyRef:
+        key: db.admin_user
+        name: subscribing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_MASTER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        key: db.admin_password
+        name: subscribing-database
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: POSTGRESQL_DATABASE
+    valueFrom:
+      secretKeyRef:
+        key: db.name
+        name: subscribing-database
+
+

--- a/config/minikube/subscribing-database/patch-service.yaml
+++ b/config/minikube/subscribing-database/patch-service.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: subscribing-datbase
+- op: add
+  path: /metadata/labels/designation
+  value: subscribing
+- op: add
+  path: /spec/selector/designation
+  value: subscribing


### PR DESCRIPTION
Provides Makefile targets and documentation to setup, build and deploy the operator to a local Minikube instance.
The setup steps provides two testing databases, one for publication another for subscription. The publication database gets some example data added to `published_data` schema of database named `publishing-datbase`.

RHINENG-15728