### PR TITLE
feat: read secrets

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - replication.console.redhat.com
   resources:
   - logicalreplications

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,7 @@
 ## Append samples of your project ##
+
+namespace: default
+
 resources:
 - replication_v1alpha1_logicalreplication.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/replication_v1alpha1_logicalreplication.yaml
+++ b/config/samples/replication_v1alpha1_logicalreplication.yaml
@@ -6,4 +6,8 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: logicalreplication-sample
 spec:
-  # TODO(user): Add fields here
+  publication:
+    name: publication_v1
+    secretName: publishing-database
+  subscription:
+    secretName: subscribing-database

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogB
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
+github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/internal/controller/database_credentials.go
+++ b/internal/controller/database_credentials.go
@@ -1,0 +1,24 @@
+package controller
+
+type DatabaseCredentials struct {
+	// Hostname
+	Host string `mapstructure:"db.host"`
+
+	// Port
+	Port string `mapstructure:"db.port"`
+
+	// Regular username
+	User string `mapstructure:"db.user"`
+
+	// Password for the regular user
+	Password string `mapstructure:"db.password"`
+
+	// Name of the database
+	DatabaseName string `mapstructure:"db.name"`
+
+	// Username of the admin account
+	AdminUser string `mapstructure:"db.admin_user"`
+
+	// Password of the admin account
+	AdminPassword string `mapstructure:"db.admin_password"`
+}

--- a/internal/controller/database_credentials_test.go
+++ b/internal/controller/database_credentials_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"github.com/go-viper/mapstructure/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DatabaseCredentials struct", func() {
+	Context("Decoding", func() {
+		It("should successfully decode from string map", func() {
+			input := map[string]string{
+				"db.host":           "db-hostname",
+				"db.port":           "1234",
+				"db.user":           "db-user",
+				"db.password":       "db-password",
+				"db.admin_password": "db-admin-password",
+				"db.admin_user":     "db-admin-user",
+				"db.name":           "db-name",
+			}
+
+			var output DatabaseCredentials
+			err := mapstructure.WeakDecode(input, &output)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.Host).To(Equal("db-hostname"))
+			Expect(output.Port).To(Equal("1234"))
+			Expect(output.User).To(Equal("db-user"))
+			Expect(output.Password).To(Equal("db-password"))
+			Expect(output.AdminPassword).To(Equal("db-admin-password"))
+			Expect(output.AdminUser).To(Equal("db-admin-user"))
+			Expect(output.DatabaseName).To(Equal("db-name"))
+		})
+
+		It("should successfully decode from bytearray map", func() {
+			input := map[string][]byte{
+				"db.host":           []byte("db-hostname"),
+				"db.port":           []byte("1234"),
+				"db.user":           []byte("db-user"),
+				"db.password":       []byte("db-password"),
+				"db.admin_password": []byte("db-admin-password"),
+				"db.admin_user":     []byte("db-admin-user"),
+				"db.name":           []byte("db-name"),
+			}
+
+			var output DatabaseCredentials
+			err := mapstructure.WeakDecode(input, &output)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(output.Host).To(Equal("db-hostname"))
+			Expect(output.Port).To(Equal("1234"))
+			Expect(output.User).To(Equal("db-user"))
+			Expect(output.Password).To(Equal("db-password"))
+			Expect(output.AdminPassword).To(Equal("db-admin-password"))
+			Expect(output.AdminUser).To(Equal("db-admin-user"))
+			Expect(output.DatabaseName).To(Equal("db-name"))
+		})
+	})
+})

--- a/internal/controller/logicalreplication_controller.go
+++ b/internal/controller/logicalreplication_controller.go
@@ -53,6 +53,14 @@ func (r *LogicalReplicationReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	log.Info("publishing database", "databaseHost", publishingDb.Host, "databasePort", publishingDb.Port)
 
+	subscribingDb, err := r.getCredentialsFromSecret(ctx, req, lr.Spec.Subscription.SecretName)
+	if err != nil {
+		log.Error(err, "getting subscribing credentials")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	log.Info("subscribing database", "databaseHost", subscribingDb.Host, "databasePort", subscribingDb.Port)
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/logicalreplication_controller_test.go
+++ b/internal/controller/logicalreplication_controller_test.go
@@ -103,6 +103,7 @@ var _ = Describe("LogicalReplication Controller", func() {
 			By("Cleanup the specific resource instance LogicalReplication")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
+
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &LogicalReplicationReconciler{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -12,6 +12,7 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -69,6 +70,23 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&LogicalReplicationReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
 
 })
 


### PR DESCRIPTION
Adds decoding and reading of two secrets defined on the CR.

Adds test suite set up. Tests can be run with standard `go test`, or preferably with `make test`.

RHINENG-16012