### PR TITLE
feat: check subscription tables

### DIFF
--- a/internal/controller/errors.go
+++ b/internal/controller/errors.go
@@ -6,6 +6,9 @@ var SecretError ReplicationErrorReason = "SecretError"
 var ConnectError ReplicationErrorReason = "ConnectError"
 var PublicationError ReplicationErrorReason = "PublicationError"
 var SubscriptionError ReplicationErrorReason = "SubscriptionError"
+var PublicationTablesError ReplicationErrorReason = "PublicationTablesError"
+var SubscriptionSchemaError ReplicationErrorReason = "SubscriptionSchemaError"
+var SubscriptionTablesError ReplicationErrorReason = "SubscriptionTablesError"
 
 type ReplicationError struct {
 	Reason ReplicationErrorReason

--- a/internal/controller/logicalreplication_controller_test.go
+++ b/internal/controller/logicalreplication_controller_test.go
@@ -211,9 +211,22 @@ var _ = Describe("LogicalReplication Controller", func() {
 			expectTableExists(subscriberDB, "published_data", "cities", expectedCitiesColumns)
 		})
 
-		It("should reconcile if table has different columns", func() {
-			By("remove table")
+		It("should reconcile if table has extra columns", func() {
+			By("add extra column")
 			_, err := subscriberDB.Exec("ALTER TABLE published_data.people ADD extra_column timestamp")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconciling the created resource")
+			_, err = runReconcile(ctx, typeNamespacedName)
+
+			Expect(err).NotTo(HaveOccurred())
+			expectTableExists(subscriberDB, "published_data", "people", expectedPeopleColumns)
+			expectTableExists(subscriberDB, "published_data", "cities", expectedCitiesColumns)
+		})
+
+		It("should reconcile if table has missing columns", func() {
+			By("drop existing column")
+			_, err := subscriberDB.Exec("ALTER TABLE published_data.cities DROP zip")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reconciling the created resource")
@@ -227,6 +240,19 @@ var _ = Describe("LogicalReplication Controller", func() {
 		It("should reconcile if table does not exist", func() {
 			By("remove table")
 			_, err := subscriberDB.Exec("DROP TABLE published_data.people")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconciling the created resource")
+			_, err = runReconcile(ctx, typeNamespacedName)
+
+			Expect(err).NotTo(HaveOccurred())
+			expectTableExists(subscriberDB, "published_data", "people", expectedPeopleColumns)
+			expectTableExists(subscriberDB, "published_data", "cities", expectedCitiesColumns)
+		})
+
+		It("should reconcile if schema does not exist", func() {
+			By("remove schema")
+			_, err := subscriberDB.Exec("DROP SCHEMA published_data CASCADE")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reconciling the created resource")

--- a/internal/controller/logicalreplication_controller_test.go
+++ b/internal/controller/logicalreplication_controller_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,18 @@ func generateDbCredentials(database string) replication.DatabaseCredentials {
 		AdminUser:     pgCredentials.AdminUser,
 		DatabaseName:  database + "_db",
 	}
+}
+
+func runReconcile(ctx context.Context, namespace types.NamespacedName) (controllerruntime.Result, error) {
+	controllerReconciler := &LogicalReplicationReconciler{
+		Client: k8sClient,
+		Scheme: k8sClient.Scheme(),
+	}
+
+	result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: namespace,
+	})
+	return result, err
 }
 
 func generateDbSecret(ctx context.Context, nn types.NamespacedName, database string) *corev1.Secret {
@@ -152,14 +165,8 @@ var _ = Describe("LogicalReplication Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reconciling the created resource")
-			controllerReconciler := &LogicalReplicationReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			_, err = runReconcile(ctx, typeNamespacedName)
 
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -169,14 +176,8 @@ var _ = Describe("LogicalReplication Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reconciling the created resource")
-			controllerReconciler := &LogicalReplicationReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			_, err = runReconcile(ctx, typeNamespacedName)
 
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -186,14 +187,8 @@ var _ = Describe("LogicalReplication Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reconciling the created resource")
-			controllerReconciler := &LogicalReplicationReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			result, err := runReconcile(ctx, typeNamespacedName)
 
-			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeTrue())
 		})
@@ -204,14 +199,8 @@ var _ = Describe("LogicalReplication Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reconciling the created resource")
-			controllerReconciler := &LogicalReplicationReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			result, err := runReconcile(ctx, typeNamespacedName)
 
-			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeTrue())
 
@@ -225,14 +214,8 @@ var _ = Describe("LogicalReplication Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reconciling the created resource")
-			controllerReconciler := &LogicalReplicationReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			result, err := runReconcile(ctx, typeNamespacedName)
 
-			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeTrue())
 

--- a/internal/replication/connect.go
+++ b/internal/replication/connect.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/lib/pq"
 )
@@ -11,8 +12,13 @@ import (
 var ErrWrongAttributes = errors.New("wrong attributes")
 
 func CredentialsToConnectionString(credentials DatabaseCredentials) string {
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
-		credentials.Host, credentials.Port, credentials.User, credentials.Password, credentials.DatabaseName, "disable")
+	return fmt.Sprintf("postgresql://%s:%s@%s:%s/%s?sslmode=%s",
+		url.QueryEscape(credentials.User),
+		url.QueryEscape(credentials.Password),
+		url.QueryEscape(credentials.Host),
+		url.QueryEscape(credentials.Port),
+		url.QueryEscape(credentials.DatabaseName),
+		url.QueryEscape("disable"))
 }
 
 func DBConnect(credentials DatabaseCredentials) (*sql.DB, error) {

--- a/internal/replication/connect.go
+++ b/internal/replication/connect.go
@@ -100,7 +100,7 @@ func CheckSubscription(db *sql.DB, name string, connStr string) error {
 
 	// subscription should be enabled
 	// and have correct connection info
-	if !subenabled || subconninfo != connStr {
+	if !subenabled || (connStr != "" && subconninfo != connStr) {
 		return ErrWrongAttributes
 	}
 

--- a/internal/replication/tables.go
+++ b/internal/replication/tables.go
@@ -1,0 +1,215 @@
+package replication
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/lib/pq"
+)
+
+type PgTableColumn struct {
+	Name                   string
+	Default                sql.NullString
+	Nullable               bool
+	Type                   string
+	CharacterMaximumLength sql.NullInt32
+	NumericPrecision       sql.NullInt32
+	NumericScale           sql.NullInt32
+	DatetimePrecision      sql.NullInt32
+}
+
+type PgTable struct {
+	Schema  string
+	Name    string
+	Columns []PgTableColumn
+}
+
+type PgIndex struct {
+	Name string
+	Def  string
+}
+
+func PublicationTables(db *sql.DB, pubname string) ([]PgTable, error) {
+	rows, err := db.Query(`SELECT n.nspname AS schema, r.relname AS name
+							 FROM pg_publication p
+							 JOIN pg_publication_rel pr ON p.oid = pr.prpubid
+							 JOIN pg_class r ON pr.prrelid = r.oid
+							 JOIN pg_namespace n ON r.relnamespace = n.oid
+							 WHERE p.pubname = $1`, pubname)
+	if err != nil {
+		return []PgTable{}, err
+	}
+	defer rows.Close()
+
+	var (
+		schema string
+		name   string
+	)
+	tables := make([]PgTable, 0, 5)
+
+	for rows.Next() {
+		err = rows.Scan(&schema, &name)
+		if err != nil {
+			return nil, err
+		}
+		tables = append(tables, PgTable{Schema: schema, Name: name})
+	}
+	return tables, nil
+}
+
+func PublicationTableDetail(db *sql.DB, table *PgTable) error {
+	rows, err := db.Query(`SELECT column_name,
+								  column_default,
+								  (is_nullable = 'YES'),
+								  data_type,
+								  character_maximum_length,
+								  numeric_precision,
+								  numeric_scale,
+								  datetime_precision
+							 FROM information_schema.columns c
+							 JOIN pg_publication_tables pt
+							   ON c.table_schema = pt.schemaname
+							  AND c.table_name = pt.tablename
+							  AND c.column_name = ANY(pt.attnames)
+							WHERE table_schema = $1 AND table_name = $2
+							ORDER BY c.ordinal_position`,
+		table.Schema, table.Name)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	columns := make([]PgTableColumn, 0)
+	for rows.Next() {
+		var col PgTableColumn
+		err := rows.Scan(
+			&col.Name,
+			&col.Default,
+			&col.Nullable,
+			&col.Type,
+			&col.CharacterMaximumLength,
+			&col.NumericPrecision,
+			&col.NumericScale,
+			&col.DatetimePrecision,
+		)
+		if err != nil {
+			return err
+		}
+		columns = append(columns, col)
+	}
+
+	table.Columns = columns
+	return nil
+}
+
+func CreateSubscriptionSchema(db *sql.DB, name string) error {
+	sql := fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, pq.QuoteIdentifier(name))
+	_, err := db.Exec(sql)
+	return err
+}
+
+func CheckSubscriptionSchema(db *sql.DB, name string) error {
+	row := db.QueryRow(`SELECT true
+						  FROM pg_namespace n
+						 WHERE n.nspname = $1`, name)
+	var exists bool
+	err := row.Scan(&exists)
+	return err
+}
+
+func equalColumns(a, b []PgTableColumn) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	// works only with exported fields (uppercase names) and not pointers
+	for i := range a {
+		if !reflect.DeepEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func createColumns(columns []PgTableColumn) string {
+	columnDefs := make([]string, len(columns))
+	for i, col := range columns {
+		columnDefs[i] = col.Name + " " + col.Type
+		if col.CharacterMaximumLength.Valid {
+			columnDefs[i] += fmt.Sprintf(" (%d)", col.CharacterMaximumLength.Int32)
+		}
+		if col.NumericPrecision.Valid {
+			columnDefs[i] += fmt.Sprintf(" (%d, %d)", col.NumericPrecision.Int32, col.NumericScale.Int32)
+		}
+		if col.DatetimePrecision.Valid {
+			columnDefs[i] += fmt.Sprintf(" (%d)", col.DatetimePrecision.Int32)
+		}
+		if !col.Nullable {
+			columnDefs[i] += " NOT NULL"
+		}
+		if col.Default.Valid {
+			columnDefs[i] += " DEFAULT " + col.Default.String
+		}
+	}
+	return strings.Join(columnDefs, ", ")
+}
+
+func CreateSubscriptionTable(db *sql.DB, table PgTable) error {
+	tableColumns := createColumns(table.Columns)
+	sql := fmt.Sprintf(`CREATE TABLE %s.%s (%s)`,
+		pq.QuoteIdentifier(table.Schema), pq.QuoteIdentifier(table.Name), tableColumns)
+	_, err := db.Exec(sql)
+	return err
+}
+
+func RenameSubscriptionTable(db *sql.DB, publicationName string, table PgTable) error {
+	sql := fmt.Sprintf(`ALTER TABLE IF EXISTS %s.%s RENAME TO %s`,
+		pq.QuoteIdentifier(table.Schema), pq.QuoteIdentifier(table.Name),
+		pq.QuoteIdentifier(table.Name+"_"+publicationName))
+	_, err := db.Exec(sql)
+	return err
+}
+
+func CheckSubscriptionTableDetail(db *sql.DB, table PgTable) error {
+	rows, err := db.Query(`SELECT column_name,
+								  column_default,
+								  (is_nullable = 'YES'),
+								  data_type,
+								  character_maximum_length,
+								  numeric_precision,
+								  numeric_scale,
+								  datetime_precision
+							 FROM information_schema.columns c
+							WHERE table_schema = $1 AND table_name = $2
+							ORDER BY c.ordinal_position`,
+		table.Schema, table.Name)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	columns := make([]PgTableColumn, 0)
+	for rows.Next() {
+		var col PgTableColumn
+		err := rows.Scan(
+			&col.Name,
+			&col.Default,
+			&col.Nullable,
+			&col.Type,
+			&col.CharacterMaximumLength,
+			&col.NumericPrecision,
+			&col.NumericScale,
+			&col.DatetimePrecision,
+		)
+		if err != nil {
+			return err
+		}
+		columns = append(columns, col)
+	}
+
+	if !equalColumns(table.Columns, columns) {
+		return ErrWrongAttributes
+	}
+	return nil
+}

--- a/internal/replication/tables.go
+++ b/internal/replication/tables.go
@@ -140,7 +140,7 @@ func equalColumns(a, b []PgTableColumn) bool {
 func createColumns(columns []PgTableColumn) string {
 	columnDefs := make([]string, len(columns))
 	for i, col := range columns {
-		columnDefs[i] = col.Name + " " + col.Type
+		columnDefs[i] = pq.QuoteIdentifier(col.Name) + " " + col.Type
 		if col.CharacterMaximumLength.Valid {
 			columnDefs[i] += fmt.Sprintf(" (%d)", col.CharacterMaximumLength.Int32)
 		}


### PR DESCRIPTION
## Summary by Sourcery

Ensure subscription schemas and tables mirror the configured publication tables by fetching publication metadata, verifying or creating schemas and tables, and handling attribute mismatches; refactor connection string formatting and extend replication utilities with new error reasons and comprehensive reconciliation tests.

New Features:
- Iterate over publication tables and ensure corresponding subscription schemas exist during reconciliation
- Ensure subscription tables match publication table structure and recreate or rename them when mismatched

Enhancements:
- Switch database connection strings to URL format with proper escaping
- Add new replication error reasons for publication tables, subscription schemas, and subscription tables

Tests:
- Add helper and tests to validate subscription tables under various reconciliation scenarios, including missing/extra columns, missing tables/schemas, absent publication, and connection failures