### PR TITLE
subscription reenablement

### DIFF
--- a/internal/controller/logicalreplication_controller.go
+++ b/internal/controller/logicalreplication_controller.go
@@ -50,10 +50,15 @@ func (r *LogicalReplicationReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	iteration := NewLogicalReplicationIteration(r.Client, ctx, req)
 
-	err := iteration.Iterate(lr)
+	currentValues, err := iteration.Iterate(lr)
 	if err != nil {
 		statusErr := r.setFailedStatus(ctx, lr, err)
 		return ctrl.Result{Requeue: true}, statusErr
+	}
+
+	err = r.setReconciledValues(ctx, lr, currentValues)
+	if err != nil {
+		return ctrl.Result{Requeue: true}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -81,6 +86,16 @@ func (r *LogicalReplicationReconciler) setFailedStatus(ctx context.Context,
 	return r.Status().Patch(ctx, obj, patch)
 }
 
+func (r *LogicalReplicationReconciler) setReconciledValues(ctx context.Context,
+	obj *replicationv1alpha1.LogicalReplication, values *replicationv1alpha1.ReconciledValues) error {
+	if values == nil {
+		return nil
+	}
+	obj.Status.ReconciledValues = *values
+	patch := client.MergeFrom(obj)
+	return r.Status().Patch(ctx, obj, patch)
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *LogicalReplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -100,56 +115,58 @@ type LogicalReplicationIteration struct {
 	subDB    *sql.DB
 }
 
-func (i *LogicalReplicationIteration) Iterate(lr *replicationv1alpha1.LogicalReplication) error {
+func (i *LogicalReplicationIteration) Iterate(lr *replicationv1alpha1.LogicalReplication) (
+	*replicationv1alpha1.ReconciledValues, error) {
 	i.log = log.FromContext(i.ctx)
 	i.obj = lr
 
 	if err := i.readCredentails(); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := i.connectDBs(); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := i.checkPublication(); err != nil {
-		return err
+		return nil, err
 	}
 
 	if i.publicationChanged() {
 		if err := i.renameTables(); err != nil {
-			return err
+			return nil, err
 		}
 
 		if err := i.disableOldSubscription(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	tables, err := i.publicationTables()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, table := range tables {
 
 		if err = i.checkSubscriptionSchema(table); err != nil {
-			return err
+			return nil, err
 		}
 
 		if err = i.checkSubscriptionTable(table); err != nil {
-			return err
+			return nil, err
 		}
 
 		if err = i.checkSubscriptionView(table); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	if err := i.checkSubscription(); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	values := i.currentValues(tables)
+	return values, nil
 }
 
 func (i *LogicalReplicationIteration) readCredentails() error {
@@ -363,6 +380,17 @@ func (i *LogicalReplicationIteration) checkSubscription() error {
 	i.log.Info("checked", "subscription", name)
 
 	return nil
+}
+
+func (i *LogicalReplicationIteration) currentValues(tables []replication.PgTable) *replicationv1alpha1.ReconciledValues {
+	values := replicationv1alpha1.ReconciledValues{
+		PublicationName:        i.obj.Spec.Publication.Name,
+		PublicationSecretHash:  replication.Checksum(replication.CredentialsToConnectionString(i.pubCreds)),
+		SubscriptionSecretHash: replication.Checksum(replication.CredentialsToConnectionString(i.subCreds)),
+		Tables:                 tables,
+	}
+
+	return &values
 }
 
 // Get secret with database credentials by name

--- a/internal/controller/logicalreplication_controller.go
+++ b/internal/controller/logicalreplication_controller.go
@@ -156,13 +156,16 @@ func (i *LogicalReplicationIteration) Iterate(lr *replicationv1alpha1.LogicalRep
 			return nil, err
 		}
 
-		if err = i.checkSubscriptionView(table); err != nil {
-			return nil, err
-		}
 	}
 
 	if err := i.checkSubscription(); err != nil {
 		return nil, err
+	}
+
+	for _, table := range tables {
+		if err = i.checkSubscriptionView(table); err != nil {
+			return nil, err
+		}
 	}
 
 	values := i.currentValues(tables)
@@ -374,6 +377,11 @@ func (i *LogicalReplicationIteration) checkSubscription() error {
 
 		default:
 			i.log.Error(err, "checking", "subscription", name)
+			return NewReplicationError(SubscriptionError, err)
+		}
+		err = replication.EnableSubscription(i.subDB, name, connStr)
+		if err != nil {
+			i.log.Error(err, "enabling", "subscription", name)
 			return NewReplicationError(SubscriptionError, err)
 		}
 	}

--- a/internal/replication/checksum.go
+++ b/internal/replication/checksum.go
@@ -1,0 +1,11 @@
+package replication
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+func Checksum(data string) string {
+	hash := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(hash[:])
+}

--- a/internal/replication/connect.go
+++ b/internal/replication/connect.go
@@ -73,12 +73,23 @@ func CreateSubscription(db *sql.DB, name string, connStr string) error {
 }
 
 func AlterSubscription(db *sql.DB, name string, connStr string) error {
-	sql := fmt.Sprintf("ALTER SUBSCRIPTION %s CONNECTION %s", pq.QuoteIdentifier(name), pq.QuoteLiteral(connStr))
+	sql := fmt.Sprintf("ALTER SUBSCRIPTION %s DISABLE", pq.QuoteIdentifier(name))
 	_, err := db.Exec(sql)
 	if err != nil {
 		return err
 	}
-	sql = fmt.Sprintf("ALTER SUBSCRIPTION %s ENABLE", pq.QuoteIdentifier(name))
+	sql = fmt.Sprintf("ALTER SUBSCRIPTION %s CONNECTION %s", pq.QuoteIdentifier(name), pq.QuoteLiteral(connStr))
+	_, err = db.Exec(sql)
+	return err
+}
+
+func EnableSubscription(db *sql.DB, name string, connStr string) error {
+	sql := fmt.Sprintf("ALTER SUBSCRIPTION %s ENABLE", pq.QuoteIdentifier(name))
+	_, err := db.Exec(sql)
+	if err != nil {
+		return err
+	}
+	sql = fmt.Sprintf("ALTER SUBSCRIPTION %s REFRESH PUBLICATION", pq.QuoteIdentifier(name))
 	_, err = db.Exec(sql)
 	return err
 }


### PR DESCRIPTION
## Summary by Sourcery

Persist reconciled replication values to CR status and automatically re-enable subscriptions during reconciliation

New Features:
- Add EnableSubscription function to re-enable and refresh subscriptions

Enhancements:
- Return ReconciledValues from the iteration and patch them into CR status after reconciliation
- Extend AlterSubscription to disable before altering connection and reorder subscription view checks
- Add Checksum utility to compute hashes of credential connection strings